### PR TITLE
MSVC Integration Installer popup workaround

### DIFF
--- a/clang.nuspec.template
+++ b/clang.nuspec.template
@@ -22,6 +22,7 @@
     <description>The LLVM compiler infrastructure supports a wide range of projects, from industrial strength compilers to specialized JIT applications to small research projects.</description>
     <releaseNotes>http://releases.llvm.org/$($tvVersion)/docs/ReleaseNotes.html</releaseNotes>
     <dependencies>
+        <dependency id="autohotkey"/>
     </dependencies>
   </metadata>
   <files>

--- a/test.ps1
+++ b/test.ps1
@@ -1,6 +1,6 @@
 param(
   [switch] $prerelease,
-  [string] $sources = "."
+  [string] $sources = ".;http://chocolatey.org/api/v2/"
 )
 
 choco uninstall clang --force -y

--- a/tools/chocolateyinstall.ps1
+++ b/tools/chocolateyinstall.ps1
@@ -22,5 +22,16 @@ $packageArgs = @{
   validExitCodes= @(0)
 }
 
+#Thanks to dtgm and the GitHub package for ideas.
+$ahkExe = 'AutoHotKey'
+$ahkFile = Join-Path $toolsDir "llvmInstall.ahk"
+$ahkProc = Start-Process -FilePath $ahkExe `
+                         -ArgumentList $ahkFile `
+                         -PassThru
+ 
+$ahkId = $ahkProc.Id
+Write-Debug "$ahkExe start time:`t$($ahkProc.StartTime.ToShortTimeString())"
+Write-Debug "Process ID:`t$ahkId"
+
 Install-ChocolateyPackage @packageArgs # https://chocolatey.org/docs/helpers-install-chocolatey-package
 Install-ChocolateyPath "$($env:SystemDrive)\Program Files\LLVM\bin" "Machine" # Machine will assert administrative rights

--- a/tools/llvmInstall.ahk
+++ b/tools/llvmInstall.ahk
@@ -1,14 +1,14 @@
 #NoEnv  ; Recommended for performance and compatibility with future AutoHotkey releases.
 #NoTrayIcon
-;#Warn  ; Enable warnings to assist with detecting common errors.
+#Warn  ; Enable warnings to assist with detecting common errors.
 SendMode Input  ; Recommended for new scripts due to its superior speed and reliability.
 SetWorkingDir %A_ScriptDir%  ; Ensures a consistent starting directory.
 SetTitleMatchMode, 2 ; Match as long as the actual title _contains_ what we match against 
 SetControlDelay -1
 
-winTitleInstall = cmd.exe
+cmdWinTitle = cmd.exe
 
-WinWait, %winTitleInstall%, , 600
-WinActivate
-Sleep, 30
-ControlSend, , {Enter}, %winTitleInstall%
+WinWait, %cmdWinTitle%, , 600
+WinActivate, %cmdWinTitle%
+WinWaitActive, %cmdWinTitle%, , 600
+ControlSend, , {Enter}, %cmdWinTitle%

--- a/tools/llvmInstall.ahk
+++ b/tools/llvmInstall.ahk
@@ -3,11 +3,12 @@
 ;#Warn  ; Enable warnings to assist with detecting common errors.
 SendMode Input  ; Recommended for new scripts due to its superior speed and reliability.
 SetWorkingDir %A_ScriptDir%  ; Ensures a consistent starting directory.
-SetTitleMatchMode, 1
+SetTitleMatchMode, 2 ; Match as long as the actual title _contains_ what we match against 
 SetControlDelay -1
 
 winTitleInstall = cmd.exe
 
 WinWait, %winTitleInstall%, , 600
 WinActivate
-ControlSend, {Enter}, %winTitleInstall%
+Sleep, 30
+ControlSend, , {Enter}, %winTitleInstall%

--- a/tools/llvmInstall.ahk
+++ b/tools/llvmInstall.ahk
@@ -1,0 +1,13 @@
+#NoEnv  ; Recommended for performance and compatibility with future AutoHotkey releases.
+#NoTrayIcon
+;#Warn  ; Enable warnings to assist with detecting common errors.
+SendMode Input  ; Recommended for new scripts due to its superior speed and reliability.
+SetWorkingDir %A_ScriptDir%  ; Ensures a consistent starting directory.
+SetTitleMatchMode, 1
+SetControlDelay -1
+
+winTitleInstall = cmd.exe
+
+WinWait, %winTitleInstall%, , 600
+WinActivate
+ControlSend, {Enter}, %winTitleInstall%


### PR DESCRIPTION
To work around the pop up of the failed MSVC integration installation